### PR TITLE
Fa5 compatibility

### DIFF
--- a/MMM-Strava.js
+++ b/MMM-Strava.js
@@ -406,7 +406,7 @@ Module.register("MMM-Strava",{
         tr.appendChild(activitySymbolTd);
 
         tr.appendChild(this.createHeaderRowStatCell("hashtag"));        // Count
-        tr.appendChild(this.createHeaderRowStatCell("arrows-h"));        // Distance
+        tr.appendChild(this.createHeaderRowStatCell("arrows-alt-h"));        // Distance
         if (this.config.elevation)
             tr.appendChild(this.createHeaderRowStatCell("line-chart"));        // Elevation  "location-arrow" "external-link-square"
 
@@ -427,7 +427,7 @@ Module.register("MMM-Strava",{
         var td =  document.createElement("td");
         td.className = "light symbol align-right stat";
         var tdIcon =  document.createElement("span");
-        tdIcon.className = "fa fa-" + icon;
+        tdIcon.className = "fas fa-" + icon;
         td.appendChild(tdIcon);
 
         return td;


### PR DESCRIPTION
Arrows symbol did not work anymore in new MM version.
Changing class prefix to "fas" ("fa" is deprecated in FA5) and name to arrows-alt-h (free for non-pro FA5 users) got them back again.
Can not yet see any other symbol disappearing from this action