### PR TITLE
digits for distance and elevation

### DIFF
--- a/MMM-Strava.js
+++ b/MMM-Strava.js
@@ -57,6 +57,7 @@ Module.register("MMM-Strava", {
         updateInterval: 10 * 1000,                      // 10 seconds
         animationSpeed: 2.5 * 1000,                     // 2.5 seconds
         debug: false,                                   // Set to true to enable extending logging
+        digits: 1,                                      // digits for distance and elevation
     },
     /**
      * @member {boolean} loading - Flag to indicate the loading state of the module.

--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ The following properties can be added to the configuration:
 | `animationSpeed` | `2500` | *Optional* - The speed of the update animation. (Milliseconds) | `0` - `5000` |
 | `locale` | `config.language` | *Optional* - The locale to be used for displaying dates - e.g. the days of the week or months or the year in chart mode. If omitted, the config.language will be used. | e.g. `en`, `en-gb`, `fr` etc |
 | `debug` | `false` | *Optional* - Outputs extended logging to the console/log | `true` = enables extended logging, `false` = disables extended logging |
+| `digits` | `1` | *Optional* - Digits for distance and elevation | `0` - ... |

--- a/templates/MMM-Strava.chart.njk
+++ b/templates/MMM-Strava.chart.njk
@@ -24,12 +24,12 @@
                     </g>
                     {% endfor %}
                     <text y="-30" fill="#ffffff">
-                        <tspan x="0" text-anchor="middle">{{ total_distance | formatDistance(1, true) }}</tspan>
+                        <tspan x="0" text-anchor="middle">{{ total_distance | formatDistance(config.digits, true) }}</tspan>
                     </text>
                     <text y="35" fill="#cccccc">
                         <tspan x="0" text-anchor="middle">{{ data[activity].total_moving_time | formatTime }}</tspan>
                         {%  if activity !== "swim" %}
-                        <tspan x="0" dy="25" text-anchor="middle">{{ data[activity].total_elevation_gain | formatElevation(1, true) }}</tspan>
+                        <tspan x="0" dy="25" text-anchor="middle">{{ data[activity].total_elevation_gain | formatElevation(config.digits, true) }}</tspan>
                         {% endif %}
                     </text>
                     <g id="activity-icon" fill="white" width="28" height="28" opacity="0.80" transform="translate(-14, -14)">
@@ -48,11 +48,11 @@
         {% else %}
 
             <div class="primary-stats">
-                <span class="actual small bright">{{ total_distance | formatDistance(1, true) }}</span>
+                <span class="actual small bright">{{ total_distance | formatDistance(config.digits, true) }}</span>
                 <ul class="inline-stats">
                     <li class="xsmall light">{{ data[activity].total_moving_time | formatTime }}</li>
                     {%  if activity !== 'swim' %}
-                    <li class="xsmall light">{{ data[activity].total_elevation_gain | formatElevation(1, true) }}</li>
+                    <li class="xsmall light">{{ data[activity].total_elevation_gain | formatElevation(config.digits, true) }}</li>
                     {% endif %}
                 </ul>
             </div>

--- a/templates/MMM-Strava.table.njk
+++ b/templates/MMM-Strava.table.njk
@@ -44,10 +44,10 @@
                 <td class="bright align-right stat">{{activity_data.count}}</td>
                 {% endif %}
                 {% if 'distance' in config.stats %}
-                <td class="bright align-right stat">{{activity_data.distance | formatDistance(1, false) }}</td>
+                <td class="bright align-right stat">{{activity_data.distance | formatDistance(config.digits, false) }}</td>
                 {% endif %}
                 {% if 'elevation' in config.stats %}
-                <td class="bright align-right stat">{{activity_data.elevation_gain | formatElevation(1, false) }}</td>
+                <td class="bright align-right stat">{{activity_data.elevation_gain | formatElevation(config.digits, false) }}</td>
                 {% endif %}
                 {% if 'moving_time' in config.stats %}
                 <td class="bright align-right stat">{{activity_data.moving_time | formatTime }}</td>


### PR DESCRIPTION
This PR makes the digits used for distance and elevation configurable.

At the moment this value is set fix to value `1`.

Now you can choose any number, if you don't want to see digits choose value `0`.

Example `digits=1` (default and current behaviour):
![grafik](https://user-images.githubusercontent.com/25914086/109402546-0d77c200-7957-11eb-9ea9-900ac0a67234.png)


Example `digits=0`:
![grafik](https://user-images.githubusercontent.com/25914086/109402524-e91be580-7956-11eb-9e42-e38878ccf835.png)
